### PR TITLE
Remove notifyDataSetChanged() by using DiffUtils

### DIFF
--- a/app/src/main/java/com/example/shoppinglist/presentation/ShopListAdapter.kt
+++ b/app/src/main/java/com/example/shoppinglist/presentation/ShopListAdapter.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.example.shoppinglist.R
 import com.example.shoppinglist.domain.ShopItem
@@ -13,8 +14,10 @@ class ShopListAdapter : RecyclerView.Adapter<ShopListAdapter.ShopItemViewHolder>
 
     var shopList = listOf<ShopItem>()
         set(value) {
+            val callback = ShopListDiffCallback(shopList, value)
+            val diffResult = DiffUtil.calculateDiff(callback)
+            diffResult.dispatchUpdatesTo(this)
             field = value
-            notifyDataSetChanged()
         }
 
     var onShopItemLongClickListener: ((ShopItem) -> Unit)? = null

--- a/app/src/main/java/com/example/shoppinglist/presentation/ShopListDiffCallback.kt
+++ b/app/src/main/java/com/example/shoppinglist/presentation/ShopListDiffCallback.kt
@@ -1,0 +1,26 @@
+package com.example.shoppinglist.presentation
+
+import androidx.recyclerview.widget.DiffUtil
+import com.example.shoppinglist.domain.ShopItem
+
+class ShopListDiffCallback(
+    private val oldList: List<ShopItem>,
+    private val newList: List<ShopItem>
+) : DiffUtil.Callback() {
+
+    override fun getOldListSize(): Int {
+        return oldList.size
+    }
+
+    override fun getNewListSize(): Int {
+        return newList.size
+    }
+
+    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        return (oldList[oldItemPosition].id == newList[newItemPosition].id)
+    }
+
+    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        return (oldList[oldItemPosition] == newList[newItemPosition])
+    }
+}


### PR DESCRIPTION
Learn how to use DiffUtils instead of notifyDataSetChanged() for updating RecyclerView